### PR TITLE
Dump params into JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add options to handle compressed files with VCF indexing workflow
 - Add `bgzip` to `index_VCF_tabix` module
 - Add PipeVal generate-checksum module
+- Add module to dump params into JSON
 
 ### Changed
 - Use `ghcr.io/uclahs-cds` as default registry

--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ Parameters:
 3. Use the `addParams` directive when importing to specify any params
 4. Call the process with the inputs where needed
 
+#### store_params_json
+
+##### Description
+
+Module that extracts all parameters into a JSON file, stored in the folder "param-log" under the default log directory. 
+
+##### How to use
+
+1. Add this repository as a submodule in the pipeline of interest
+2. Include the `store_params_json` process from the module `main.nf` with a relative path
+3. Call the process
+
 ### Compress and Index VCF File
 ##### Description
 Module for compressing and indexing VCF/GFF files, the input should be compressed or uncompressed *.vcf or *.gff files.

--- a/modules/common/store_params_json/functions.nf
+++ b/modules/common/store_params_json/functions.nf
@@ -1,0 +1,13 @@
+/*
+ * Utility functions for logging parameters
+ */
+
+/*
+ * Function to initialize default values and to generate a Groovy Map of options used by the process
+ */
+def initOptions(Map args) {
+    Map options = [:]
+    options.log_output_dir          = args.log_output_dir ?: params.log_output_dir
+    return options
+    }
+

--- a/modules/common/store_params_json/main.nf
+++ b/modules/common/store_params_json/main.nf
@@ -1,0 +1,12 @@
+/* groovylint-disable CompileStatic */
+import groovy.json.JsonOutput
+
+process store_params_json {
+    output:
+    path 'pipeline_params.json' 
+
+    exec:
+    json_params = JsonOutput.prettyPrint(JsonOutput.toJson(params))
+    writer = file("${task.workDir}/pipeline_params.json")
+    writer.write(json_params)
+}

--- a/modules/common/store_params_json/main.nf
+++ b/modules/common/store_params_json/main.nf
@@ -2,8 +2,12 @@
 import groovy.json.JsonOutput
 
 process store_params_json {
+    publishDir path: "${params.log_output_dir}/param-log",
+    mode: 'copy',
+    pattern: '*.json'
+
     output:
-    path 'pipeline_params.json' 
+    path 'pipeline_params.json'
 
     exec:
     json_params = JsonOutput.prettyPrint(JsonOutput.toJson(params))

--- a/modules/common/store_params_json/main.nf
+++ b/modules/common/store_params_json/main.nf
@@ -1,16 +1,15 @@
+
 /* groovylint-disable CompileStatic */
 import groovy.json.JsonOutput
 
-process store_params_json {
-    publishDir path: "${params.log_output_dir}/param-log",
-    mode: 'copy',
-    pattern: '*.json'
+include { initOptions } from './functions.nf'
 
-    output:
-    path 'pipeline_params.json'
-
-    exec:
+void store_params_json() {
+    Map ps = [:]
+    def options = initOptions(ps)
     json_params = JsonOutput.prettyPrint(JsonOutput.toJson(params))
-    writer = file("${task.workDir}/pipeline_params.json")
-    writer.write(json_params)
+    File file = new File("${options.log_output_dir}/nextflow-log/params.json")
+    File logdir = new File("${options.log_output_dir}/nextflow-log")
+    logdir.mkdirs()
+    file.write(json_params)
 }


### PR DESCRIPTION
Adds a module to dump all parameters into a JSON file.

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [X] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the pipeline on at least one A-mini sample.

## Testing Results

- RNA A-mini-N2
    - sample:    RNA A-mini-N2
    - config:    `/hot/software/pipeline/pipeline-call-RNAEditingSite/Nextflow/development/unreleased/jsalmingo-check-param-dump/call-RNAEditingSite-A-mini-n2-test.config`
    - output:    `/hot/software/pipeline/pipeline-call-RNAEditingSite/Nextflow/development/unreleased/jsalmingo-check-param-dump/output`
    - benchmarking: `/hot/software/pipeline/pipeline-call-RNAEditingSite/Nextflow/development/unreleased/jsalmingo-check-param-dump/output/call-RNAEditingSite-6.0.0/CPCG0196-F1-A-mini-n2-strand-correct-false/log-call-RNAEditingSite-6.0.0-20231002T222004Z/nextflow-log/trace.txt`