### PR TITLE
Add `ext.capture_logs` to processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - File deletion module: add disk usage monitoring before and after deletion
 - PipeVal module: nested log directories
 - Update PipeVal to v4.0.0-rc.2
+- Set `ext.capture_logs` to false for all processes to disable new `setup_process_afterscript()` behavior.

--- a/modules/PipeVal/generate-checksum/main.nf
+++ b/modules/PipeVal/generate-checksum/main.nf
@@ -30,6 +30,9 @@ process generate_checksum_PipeVal {
         pattern: "*.${options.checksum_alg}",
         mode: "copy" 
 
+    // This process uses the publishDir method to save the log files
+    ext capture_logs: false
+
     input:
         path(input_file)
 

--- a/modules/PipeVal/validate/main.nf
+++ b/modules/PipeVal/validate/main.nf
@@ -24,6 +24,9 @@ process run_validate_PipeVal {
         mode: "copy",
         saveAs: { "${task.process.split(':')[-1]}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
 
+    // This process uses the publishDir method to save the log files
+    ext capture_logs: false
+
     input:
         path(file_to_validate)
 

--- a/modules/common/extract_genome_intervals/main.nf
+++ b/modules/common/extract_genome_intervals/main.nf
@@ -27,6 +27,9 @@ process extract_GenomeIntervals {
                pattern: ".command.*",
                saveAs: { "${task.process.replace(':', '/')}/log${file(it).getName()}" }
 
+    // This process uses the publishDir method to save the log files
+    ext capture_logs: false
+
     input:
     path(reference_dict)
 

--- a/modules/common/intermediate_file_removal/main.nf
+++ b/modules/common/intermediate_file_removal/main.nf
@@ -24,6 +24,9 @@ process remove_intermediate_files {
       mode: "copy",
       saveAs: { "${task.process.split(':')[-1]}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
 
+    // This process uses the publishDir method to save the log files
+    ext capture_logs: false
+
     input:
     path(input_file_to_remove), stageAs: "delete.file"
     val(ready_for_deletion_signal)


### PR DESCRIPTION
This is a complement to to https://github.com/uclahs-cds/pipeline-Nextflow-config/pull/64, in that it explicitly disables the new behaviors introduced by `methods.setup_process_afterscript()` for all processes defined in this repository.

Without this, the log files created by these processes would be saved twice. Theoretically we could refactor these processes to remove the explicit `publishDir` directives, but that has a few issues:

1. It assumes that every pipeline using this repository as a submodule is using `setup_process_afterscript()`
2. The `publishDir`s in this repository have some extra logic to define the output directory based on "options" parameters ([example](https://github.com/uclahs-cds/pipeline-Nextflow-module/blob/4597ebcfa71588a083550123f63aebd5795b7c4d/modules/PipeVal/generate-checksum/main.nf#L3-L4)). There's not an easy mechanism to set the `ext` properties used by the new function, meaning there would be a bunch of busywork to adapt all the existing pipelines.

Given that `methods.setup_process_afterscript()` is intended to make things easier, let's leave the `publishDir`s on these common processes!


- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample.

I ran https://github.com/uclahs-cds/pipeline-recalibrate-BAM/commit/018ba8ae796050c6be318453ce662990063e3062 through NFTest: `/hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/unreleased/nwiltsie-logfile-collection-2/log-nftest-20240520T215931Z.log`. That run produced exactly the same log files as a run on `main`, with no additions or subtractions.