### PR TITLE
Change PipeVal command because the interface was changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - PipeVal module: nested log directories
 - Update PipeVal to v4.0.0-rc.2
 - Set `ext.capture_logs` to false for all processes to disable new `setup_process_afterscript()` behavior.
+- Change PipeVal command since the interface was changed.

--- a/modules/PipeVal/generate-checksum/functions.nf
+++ b/modules/PipeVal/generate-checksum/functions.nf
@@ -9,8 +9,8 @@
 def initOptions(Map args) {
     def Map options = [:]
     options.log_output_dir          = args.log_output_dir ?: params.log_output_dir
-    options.docker_image_version    = args.docker_image_version ?: '4.0.0-rc.2'
-    options.output_dir     	    = args.output_dir ?: params.output_dir
+    options.docker_image_version    = args.docker_image_version ?: '5.0.0-rc.3'
+    options.output_dir              = args.output_dir ?: params.output_dir
     options.docker_image            = "ghcr.io/uclahs-cds/pipeval:${options.docker_image_version}"
     options.process_label           = args.containsKey('process_label') ? args.process_label : 'none'
     options.main_process            = args.main_process ? args.main_process : ''

--- a/modules/PipeVal/generate-checksum/main.nf
+++ b/modules/PipeVal/generate-checksum/main.nf
@@ -8,10 +8,10 @@ options = initOptions(params.options)
 *
 *   @input  file_to_validate    path    File to generate checksum
 *
-*   @params output_dir  path    Directory for saving checksums 
+*   @params output_dir  path    Directory for saving checksums
 *   @params log_output_dir  path    Directory for saving log files
 *   @params docker_image_version    string  Version of PipeVal image for validation
-*   @params checksum_alg    string  (Optional) Select between 'sha512'(default) or 'md5' 
+*   @params checksum_alg    string  (Optional) Select between 'sha512'(default) or 'md5'
 *   @params main_process    string  (Optional) Name of main output directory
 */
 process generate_checksum_PipeVal {
@@ -28,7 +28,7 @@ process generate_checksum_PipeVal {
 
     publishDir path: "${options.output_dir}",
         pattern: "*.${options.checksum_alg}",
-        mode: "copy" 
+        mode: "copy"
 
     // This process uses the publishDir method to save the log files
     ext capture_logs: false
@@ -43,6 +43,6 @@ process generate_checksum_PipeVal {
     script:
     """
     set -euo pipefail
-    generate-checksum -t ${options.checksum_alg} ${input_file} ${options.checksum_extra_args}
+    pipeval generate-checksum -t ${options.checksum_alg} ${input_file} ${options.checksum_extra_args}
     """
 }

--- a/modules/PipeVal/generate-checksum/main.nf
+++ b/modules/PipeVal/generate-checksum/main.nf
@@ -38,11 +38,17 @@ process generate_checksum_PipeVal {
 
     output:
         path(".command.*")
-	path("*.${options.checksum_alg}")
+        path("*.${options.checksum_alg}")
 
     script:
     """
     set -euo pipefail
-    pipeval generate-checksum -t ${options.checksum_alg} ${input_file} ${options.checksum_extra_args}
+
+    if command -v pipeval &> /dev/null
+    then
+        pipeval generate-checksum -t ${options.checksum_alg} ${input_file} ${options.checksum_extra_args}
+    else
+        generate-checksum -t ${options.checksum_alg} ${input_file} ${options.checksum_extra_args}
+    fi
     """
 }

--- a/modules/PipeVal/validate/functions.nf
+++ b/modules/PipeVal/validate/functions.nf
@@ -9,7 +9,7 @@
 def initOptions(Map args) {
     def Map options = [:]
     options.log_output_dir          = args.log_output_dir ?: params.log_output_dir
-    options.docker_image_version    = args.docker_image_version ?: '4.0.0-rc.2'
+    options.docker_image_version    = args.docker_image_version ?: '5.0.0-rc.3'
     options.docker_image            = "ghcr.io/uclahs-cds/pipeval:${options.docker_image_version}"
     options.process_label           = args.containsKey('process_label') ? args.process_label : 'none'
     options.main_process            = args.main_process ? args.main_process : ''

--- a/modules/PipeVal/validate/main.nf
+++ b/modules/PipeVal/validate/main.nf
@@ -38,6 +38,12 @@ process run_validate_PipeVal {
     script:
     """
     set -euo pipefail
-    pipeval validate ${file_to_validate} ${options.validate_extra_args} > 'validation.txt'
+
+    if command -v pipeval &> /dev/null
+    then
+        pipeval validate ${file_to_validate} ${options.validate_extra_args} > 'validation.txt'
+    else
+        validate ${file_to_validate} ${options.validate_extra_args} > 'validation.txt'
+    fi
     """
 }

--- a/modules/PipeVal/validate/main.nf
+++ b/modules/PipeVal/validate/main.nf
@@ -38,6 +38,6 @@ process run_validate_PipeVal {
     script:
     """
     set -euo pipefail
-    validate ${file_to_validate} ${options.validate_extra_args} > 'validation.txt'
+    pipeval validate ${file_to_validate} ${options.validate_extra_args} > 'validation.txt'
     """
 }


### PR DESCRIPTION
PipeVal was updated to have the top-level command `pipeval`, but the module wasn't updated.

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [ ] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [X] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the pipeline on at least one A-mini sample.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...

## Testing Results

- Case 1
    - sample:    <!-- e.g. A-mini S2.T-1, A-mini S2.T-n1 -->
    - input csv: <!-- path/to/input.csv -->
    - config:    <!-- path/to/xxx.config -->
    - output:    <!-- path/to/output -->
- Case 2
    - sample:    <!-- e.g. A-mini S2.T-1, A-mini S2.T-n1 -->
    - input csv: <!-- path/to/input.csv -->
    - config:    <!-- path/to/xxx.config -->
    - output:    <!-- path/to/output -->