### PR TITLE
Add `run_validate_PipeVal_with_metadata` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add options to handle compressed files with VCF indexing workflow
 - Add `bgzip` to `index_VCF_tabix` module
 - Add PipeVal generate-checksum module
+- Add `run_validate_PipeVal_with_metadata` method
 
 ### Changed
 - Use `ghcr.io/uclahs-cds` as default registry

--- a/README.md
+++ b/README.md
@@ -116,12 +116,20 @@ Outputs:
 
 ##### Description
 
-Module for validating files and directories using PipeVal
+Module for validating files and directories using PipeVal. There are two nearly-identical methods in this module: `run_validate_PipeVal` and `run_validate_PipeVal_with_metadata`.
 
 Tools used: `PipeVal`.
 
 Inputs:
   - `file_to_validate`: path for file or directory to validate
+
+Inputs:
+  - `run_validate_PipeVal`:
+    - `file_to_validate`: path for file to generate a checksum
+  - `run_validate_PipeVal_with_metadata` Inputs:
+    - A tuple of:
+      - `file_to_validate`: path for file to generate a checksum
+      - `metadata`: arbitrary `val` passed through to the output
 
 Parameters:
   - `log_output_dir`: directory for storing log files
@@ -129,10 +137,14 @@ Parameters:
   - `process_label`: assign Nextflow process label to process to control resource allocation. For specific CPU and memory allocation, include static allocations in node-specific config files
   - `main_process`: Set output directory to the specified main process instead of `PipeVal-4.0.0-rc.2`
 
+Outputs:
+  - `validation_result`: path of file with validation output text
+  - `validated_file`: `file_to_validate` or tuple of (`file_to_validate`, `metadata`)
+
 ##### How to use
 
 1. Add this repository as a submodule in the pipeline of interest
-2. Include the `run_validate_PipeVal` process from the module `main.nf` with a relative path
+2. Include the `run_validate_PipeVal` or `run_validate_PipeVal_with_metadata` process from the module `main.nf` with a relative path
 3. Use the `addParams` directive when importing to specify any params
 4. Call the process with the inputs where needed
 5. Aggregate and save the output validation files as needed

--- a/modules/PipeVal/validate/main.nf
+++ b/modules/PipeVal/validate/main.nf
@@ -87,6 +87,12 @@ process run_validate_PipeVal_with_metadata {
     script:
     """
     set -euo pipefail
-    validate ${file_to_validate} ${options.validate_extra_args} > 'validation.txt'
+
+    if command -v pipeval &> /dev/null
+    then
+        pipeval validate ${file_to_validate} ${options.validate_extra_args} > 'validation.txt'
+    else
+        validate ${file_to_validate} ${options.validate_extra_args} > 'validation.txt'
+    fi
     """
 }

--- a/modules/PipeVal/validate/main.nf
+++ b/modules/PipeVal/validate/main.nf
@@ -41,3 +41,46 @@ process run_validate_PipeVal {
     validate ${file_to_validate} ${options.validate_extra_args} > 'validation.txt'
     """
 }
+
+/**
+*   Nextflow module for validating files and directories.
+*
+*   This variant accepts and emits a tuple so that the validated path can be
+*   associated with arbitrary metadata.
+*
+*   @input  file_to_validate    path    File or directory to validate
+*   @input  metadata    val Arbitrary metadata associated with the value.
+*
+*   @params log_output_dir  path    Directory for saving log files
+*   @params docker_image_version    string  Version of PipeVal image for validation
+*   @params main_process    string  (Optional) Name of main output directory
+*/
+process run_validate_PipeVal_with_metadata {
+    container options.docker_image
+    label options.process_label
+
+    publishDir path: { options.main_process ?
+        "${options.log_output_dir}/process-log/${options.main_process}" :
+        "${options.log_output_dir}/process-log/PipeVal-${options.docker_image_version}"
+        },
+        pattern: ".command.*",
+        mode: "copy",
+        saveAs: { "${task.process.split(':')[-1]}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
+
+    // This process uses the publishDir method to save the log files
+    ext capture_logs: false
+
+    input:
+        tuple path(file_to_validate), val(metadata)
+
+    output:
+        path(".command.*")
+        path("validation.txt"), emit: validation_result
+        tuple path(file_to_validate), val(metadata), emit: validated_file
+
+    script:
+    """
+    set -euo pipefail
+    validate ${file_to_validate} ${options.validate_extra_args} > 'validation.txt'
+    """
+}


### PR DESCRIPTION
This PR adds a new `run_validate_PipeVal_with_metadata` method. That method is functionally equivalent to `run_validate_PipeVal` except that it takes a `tuple` as input, rather than a single `path`, and emits the same thing as `validated_file`:

### `run_validate_PipeVal`:

https://github.com/uclahs-cds/pipeline-Nextflow-module/blob/7498d12e5983c29000b40a889ee07408ffb2bae6/modules/PipeVal/validate/main.nf#L30-L36

### `run_validate_PipeVal_with_metadata`:

https://github.com/uclahs-cds/pipeline-Nextflow-module/blob/7498d12e5983c29000b40a889ee07408ffb2bae6/modules/PipeVal/validate/main.nf#L73-L79

With that change, the `validated_file` output channel (with a little manipulation) can be fed to downstream processes directly. As an example, take this logic from pipeline-recalibrate-BAM (abbreviated):

```nextflow
workflow {
    Channel.from(params.samples_to_process)
        .map{ sample -> ['index': indexFile(sample.path)] + sample }
        .set{ input_ch_samples_with_index }

    input_ch_samples_with_index
        .map{ sample -> [sample.path, sample.index] }
        .flatten()
        .set{ input_ch_validate }

    // Outputs of this process are not used anywhere
    run_validate_PipeVal(input_ch_validate)

    // This process is not gated by run_validate_PipeVal
    input_ch_samples_with_index
        .filter{ it.sample_type == 'normal' }
        .map{ it -> [sanitize_string(it.id)] }
        .join(run_GetPileupSummaries_GATK.out.pileupsummaries)
        .set{ normal_pileupsummaries }

    ...
}
```
`input_ch_samples_with_index.dump()`:
```
['index':/hot/resource/SMC-HET/tumours/A-mini/bams/n1/output/S2.T-n1.bam.bai, 'id':'S2_v1.1.5', 'path':'/hot/resource/SMC-HET/tumours/A-mini/bams/n1/output/S2.T-n1.bam', 'sample_type':'tumor']
```

That can be changed to this (tested but not reviewed/merged):

```nextflow
workflow {
    Channel.from(params.samples_to_process)
        .flatMap { sample ->
            def all_metadata = sample.findAll { it.key != "path" }
            return [
                [sample.path, [all_metadata, "path"]],
                [indexFile(sample.path), [[id: sample.id], "index"]]
            ]
        } | run_validate_PipeVal_with_metadata

    run_validate_PipeVal_with_metadata.out.validated_file
        .map { filename, metadata -> [metadata[0].id, metadata[0] + [(metadata[1]): filename]] }
        .groupTuple()
        .map { it[1].inject([:]) { result, i -> result + i } }
        .set { validated_samples_with_index }

    // This process is now downstream from PipeVal
    validated_samples_with_index
        .filter{ it.sample_type == 'normal' }
        .map{ it -> [sanitize_string(it.id)] }
        .join(run_GetPileupSummaries_GATK.out.pileupsummaries)
        .set{ normal_pileupsummaries }
    
    ...
}
```
`validated_samples_with_index.dump()`:
```
['id':'S2_v1.1.5', 'sample_type':'tumor', 'path':/scratch/174611/ee/64c24ef90214d88bcd0bfe7c5376af/S2.T-n1.bam, 'index':/scratch/174611/f5/9083727eee12f7456acaed9b5bea48/S2.T-n1.bam.bai]
```


- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample.

## Testing Results

Modified pipeline-recalibrate-BAM NFTest run: `/hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/unreleased/nwiltsie-refactor/log-nftest-20240613T202121Z.log`