### PR TITLE
update process log naming standard to include workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Change PipeVal command since the interface was changed.
 - Change indexFile to support cram format type
 - Set `ext.capture_logs` to false for `index_VCF_tabix` processes
+- Change process logs filename standard from `processName/` to `workflowName/processName`
 
 ### Fixed
 - Fix default log_output_dir in `run_index_SAMtools`

--- a/modules/PipeVal/generate-checksum/main.nf
+++ b/modules/PipeVal/generate-checksum/main.nf
@@ -24,7 +24,7 @@ process generate_checksum_PipeVal {
         },
         pattern: ".command.*",
         mode: "copy",
-        saveAs: { "${task.process.replace(':', '/')}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
+        saveAs: { "${task.process.replace(':', '/').replace('_', '-')}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
 
     publishDir path: "${options.output_dir}",
         pattern: "*.${options.checksum_alg}",

--- a/modules/PipeVal/generate-checksum/main.nf
+++ b/modules/PipeVal/generate-checksum/main.nf
@@ -24,7 +24,7 @@ process generate_checksum_PipeVal {
         },
         pattern: ".command.*",
         mode: "copy",
-        saveAs: { "${task.process.split(':')[-1]}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
+        saveAs: { "${task.process.replace(':', '/')}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
 
     publishDir path: "${options.output_dir}",
         pattern: "*.${options.checksum_alg}",

--- a/modules/PipeVal/generate-checksum/main.nf
+++ b/modules/PipeVal/generate-checksum/main.nf
@@ -24,7 +24,7 @@ process generate_checksum_PipeVal {
         },
         pattern: ".command.*",
         mode: "copy",
-        saveAs: { "${task.process.replace(':', '/').replace('_', '-')}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
+        saveAs: { "${task.process.replace(':', '/')}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
 
     publishDir path: "${options.output_dir}",
         pattern: "*.${options.checksum_alg}",

--- a/modules/PipeVal/validate/main.nf
+++ b/modules/PipeVal/validate/main.nf
@@ -22,7 +22,7 @@ process run_validate_PipeVal {
         },
         pattern: ".command.*",
         mode: "copy",
-        saveAs: { "${task.process.split(':')[-1]}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
+        saveAs: { "${task.process.replace(':', '/')}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
 
     // This process uses the publishDir method to save the log files
     ext capture_logs: false
@@ -71,7 +71,7 @@ process run_validate_PipeVal_with_metadata {
         },
         pattern: ".command.*",
         mode: "copy",
-        saveAs: { "${task.process.split(':')[-1]}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
+        saveAs: { "${task.process.replace(':', '/')}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
 
     // This process uses the publishDir method to save the log files
     ext capture_logs: false

--- a/modules/SAMtools/index/main.nf
+++ b/modules/SAMtools/index/main.nf
@@ -24,7 +24,7 @@ process run_index_SAMtools {
         },
         pattern: ".command.*",
         mode: "copy",
-        saveAs: { "${task.process.replace(':', '/')}-${sample}/log${file(it).getName()}" }
+        saveAs: { "${task.process.replace(':', '/')}/${sample}/log${file(it).getName()}" }
 
     publishDir path: "${options.output_dir}",
         mode: "copy",

--- a/modules/SAMtools/index/main.nf
+++ b/modules/SAMtools/index/main.nf
@@ -24,7 +24,7 @@ process run_index_SAMtools {
         },
         pattern: ".command.*",
         mode: "copy",
-        saveAs: { "${task.process.split(':')[-1]}/${task.process.split(':')[-1]}-${sample}/log${file(it).getName()}" }
+        saveAs: { "${task.process.replace(':', '/')}-${sample}/log${file(it).getName()}" }
 
     publishDir path: "${options.output_dir}",
         mode: "copy",

--- a/modules/common/extract_genome_intervals/main.nf
+++ b/modules/common/extract_genome_intervals/main.nf
@@ -25,7 +25,7 @@ process extract_GenomeIntervals {
     publishDir path: "${options.log_output_dir}/process-log",
                mode: "copy",
                pattern: ".command.*",
-               saveAs: { "${task.process.replace(':', '/')}/log${file(it).getName()}" }
+               saveAs: { "${task.process.replace(':', '/').replace('_', '-')}/log${file(it).getName()}" }
 
     // This process uses the publishDir method to save the log files
     ext capture_logs: false

--- a/modules/common/extract_genome_intervals/main.nf
+++ b/modules/common/extract_genome_intervals/main.nf
@@ -25,7 +25,7 @@ process extract_GenomeIntervals {
     publishDir path: "${options.log_output_dir}/process-log",
                mode: "copy",
                pattern: ".command.*",
-               saveAs: { "${task.process.replace(':', '/').replace('_', '-')}/log${file(it).getName()}" }
+               saveAs: { "${task.process.replace(':', '/')}/log${file(it).getName()}" }
 
     // This process uses the publishDir method to save the log files
     ext capture_logs: false

--- a/modules/common/index_VCF_tabix/modules.nf
+++ b/modules/common/index_VCF_tabix/modules.nf
@@ -18,7 +18,7 @@ process check_compression_bgzip {
     publishDir path: "${options.log_output_dir}",
                mode: "copy",
                pattern: ".command.*",
-               saveAs: { "${task.process.replace(':', '/')}-${id}/log${file(it).getName()}" }
+               saveAs: { "${task.process.replace(':', '/')}/${id}/log${file(it).getName()}" }
 
     // This process uses the publishDir method to save the log files
     ext capture_logs: false
@@ -60,7 +60,7 @@ process uncompress_file_gunzip {
     publishDir path: "${options.log_output_dir}",
                mode: "copy",
                pattern: ".command.*",
-               saveAs: { "${task.process.replace(':', '/')}-${id}/log${file(it).getName()}" }
+               saveAs: { "${task.process.replace(':', '/')}/${id}/log${file(it).getName()}" }
 
     // This process uses the publishDir method to save the log files
     ext capture_logs: false
@@ -107,7 +107,7 @@ process compress_VCF_bgzip {
     publishDir path: "${options.log_output_dir}",
                mode: "copy",
                pattern: ".command.*",
-               saveAs: { "${task.process.replace(':', '/')}-${id}/log${file(it).getName()}" }
+               saveAs: { "${task.process.replace(':', '/')}/${id}/log${file(it).getName()}" }
 
     // This process uses the publishDir method to save the log files
     ext capture_logs: false
@@ -152,7 +152,7 @@ process index_VCF_tabix {
     publishDir path: "${options.log_output_dir}",
                mode: "copy",
                pattern: ".command.*",
-               saveAs: { "${task.process.replace(':', '/')}-${id}/log${file(it).getName()}" }
+               saveAs: { "${task.process.replace(':', '/')}/${id}/log${file(it).getName()}" }
     
     // This process uses the publishDir method to save the log files
     ext capture_logs: false

--- a/modules/common/intermediate_file_removal/main.nf
+++ b/modules/common/intermediate_file_removal/main.nf
@@ -22,7 +22,7 @@ process remove_intermediate_files {
     publishDir path: "${options.log_output_dir}",
       pattern: ".command.*",
       mode: "copy",
-      saveAs: { "${task.process.split(':')[-1]}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
+      saveAs: { "${task.process.replace(':', '/')}/${task.process.split(':')[-1]}-${task.index}/log${file(it).getName()}" }
 
     // This process uses the publishDir method to save the log files
     ext capture_logs: false


### PR DESCRIPTION
This PR standardizes process log filename structure to `workflowName/processName`

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the pipeline on at least one A-mini sample.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #50 

## Testing Results

PENDING